### PR TITLE
Fix code bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Loading animation with one `color`
 ```dart
 Scaffold(
     body: Center(
-      child: LoadingAnimationWidget.staggeredDotWave(
+      child: LoadingAnimationWidget.staggeredDotsWave(
         color: Colors.white,
         size: 200,
       ),


### PR DESCRIPTION
The example in the README uses `LoadingAnimationWidget.staggeredDotWave`, which doesn't exist. The widget is called `LoadingAnimationWidget.staggeredDotsWave`.