### PR TITLE
Fix CurvedAnimation memory leaks

### DIFF
--- a/lib/src/beat/beat.dart
+++ b/lib/src/beat/beat.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
 import '../widgets/draw_ring.dart';
 
 class Beat extends StatefulWidget {
@@ -44,38 +46,21 @@ class _BeatState extends State<Beat> with SingleTickerProviderStateMixin {
             Visibility(
               visible: _animationController.value <= 0.7,
               child: Transform.scale(
-                scale: Tween<double>(begin: 0.15, end: 1.0)
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.0,
-                          0.7,
-                          curve: Curves.easeInCubic,
-                        ),
-                      ),
-                    )
-                    .value,
+                scale: _animationController.evalDouble(
+                  from: 0.15,
+                  end: 0.7,
+                  curve: Curves.easeInCubic,
+                ),
                 child: Opacity(
-                  opacity: Tween<double>(begin: 0.0, end: 1.0)
-                      .animate(
-                        CurvedAnimation(
-                          parent: _animationController,
-                          curve: const Interval(0.0, 0.2),
-                        ),
-                      )
-                      .value,
+                  opacity: _animationController.evalDouble(end: 0.2),
                   child: Ring.draw(
                     color: color,
                     size: size,
-                    strokeWidth: Tween<double>(begin: size / 5, end: size / 8)
-                        .animate(
-                          CurvedAnimation(
-                            parent: _animationController,
-                            curve: const Interval(0.0, 0.7),
-                          ),
-                        )
-                        .value,
+                    strokeWidth: _animationController.evalDouble(
+                      from: size / 5,
+                      to: size / 8,
+                      end: 0.7,
+                    ),
                   ),
                 ),
               ),
@@ -85,24 +70,23 @@ class _BeatState extends State<Beat> with SingleTickerProviderStateMixin {
               child: Ring.draw(
                 color: color,
                 size: size,
-                strokeWidth: size / 8,
+                strokeWidth: _animationController.evalDouble(
+                  from: size / 5,
+                  to: size / 8,
+                  end: 0.7,
+                ),
               ),
             ),
             Visibility(
               visible: _animationController.value <= 0.8 &&
                   _animationController.value >= 0.7,
               child: Transform.scale(
-                scale: Tween<double>(begin: 1.0, end: 1.15)
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.7,
-                          0.8,
-                        ),
-                      ),
-                    )
-                    .value,
+                scale: _animationController.evalDouble(
+                  from: 1,
+                  to: 1.15,
+                  begin: 0.7,
+                  end: 0.8,
+                ),
                 child: Ring.draw(
                   color: color,
                   size: size,
@@ -113,17 +97,12 @@ class _BeatState extends State<Beat> with SingleTickerProviderStateMixin {
             Visibility(
               visible: _animationController.value >= 0.8,
               child: Transform.scale(
-                scale: Tween<double>(begin: 1.15, end: 1.0)
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.8,
-                          0.9,
-                        ),
-                      ),
-                    )
-                    .value,
+                scale: _animationController.evalDouble(
+                  from: 1.15,
+                  to: 1,
+                  begin: 0.8,
+                  end: 0.9,
+                ),
                 child: Ring.draw(
                   color: color,
                   size: size,

--- a/lib/src/bouncing_ball/bouncing_ball.dart
+++ b/lib/src/bouncing_ball/bouncing_ball.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
 import '../widgets/draw_dot.dart';
 
 class BouncingBall extends StatefulWidget {
@@ -45,21 +47,13 @@ class _BouncingBallState extends State<BouncingBall>
               Visibility(
                 visible: _animationController.value <= 0.4,
                 child: Transform.translate(
-                  offset: Tween<Offset>(
-                    begin: Offset.zero,
-                    end: Offset(0, size - ballSize),
-                  )
-                      .animate(
-                        CurvedAnimation(
-                          parent: _animationController,
-                          curve: const Interval(
-                            0.0,
-                            0.4,
-                            curve: Curves.easeIn,
-                          ),
-                        ),
-                      )
-                      .value,
+                  offset: _animationController.eval(
+                    Tween<Offset>(
+                      begin: Offset.zero,
+                      end: Offset(0, size - ballSize),
+                    ),
+                    curve: const Interval(0, 0.4, curve: Curves.easeIn),
+                  ),
                   child: Align(
                     alignment: Alignment.topCenter,
                     child: DrawDot.circular(
@@ -76,34 +70,18 @@ class _BouncingBallState extends State<BouncingBall>
                   alignment: Alignment.bottomCenter,
                   child: DrawDot.elliptical(
                     color: color,
-                    width: Tween<double>(
-                      begin: ballSize,
-                      end: ballSize + radiusDisplacement,
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: _animationController,
-                            curve: const Interval(
-                              0.4,
-                              0.45,
-                            ),
-                          ),
-                        )
-                        .value,
-                    height: Tween<double>(
-                      begin: ballSize,
-                      end: ballSize - radiusDisplacement,
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: _animationController,
-                            curve: const Interval(
-                              0.4,
-                              0.45,
-                            ),
-                          ),
-                        )
-                        .value,
+                    width: _animationController.evalDouble(
+                      from: ballSize,
+                      to: ballSize + radiusDisplacement,
+                      begin: 0.4,
+                      end: 0.45,
+                    ),
+                    height: _animationController.evalDouble(
+                      from: ballSize,
+                      to: ballSize - radiusDisplacement,
+                      begin: 0.4,
+                      end: 0.45,
+                    ),
                   ),
                 ),
               ),
@@ -114,55 +92,31 @@ class _BouncingBallState extends State<BouncingBall>
                   alignment: Alignment.bottomCenter,
                   child: DrawDot.elliptical(
                     color: color,
-                    width: Tween<double>(
-                      begin: ballSize + radiusDisplacement,
-                      end: ballSize,
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: _animationController,
-                            curve: const Interval(
-                              0.45,
-                              0.5,
-                            ),
-                          ),
-                        )
-                        .value,
-                    height: Tween<double>(
-                      begin: ballSize - radiusDisplacement,
-                      end: ballSize,
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: _animationController,
-                            curve: const Interval(
-                              0.45,
-                              0.5,
-                            ),
-                          ),
-                        )
-                        .value,
+                    width: _animationController.evalDouble(
+                      from: ballSize + radiusDisplacement,
+                      to: ballSize,
+                      begin: 0.45,
+                      end: 0.5,
+                    ),
+                    height: _animationController.evalDouble(
+                      from: ballSize - radiusDisplacement,
+                      to: ballSize,
+                      begin: 0.45,
+                      end: 0.5,
+                    ),
                   ),
                 ),
               ),
               Visibility(
                 visible: _animationController.value >= 0.5,
                 child: Transform.translate(
-                  offset: Tween<Offset>(
-                    begin: Offset(0, size - ballSize),
-                    end: Offset.zero,
-                  )
-                      .animate(
-                        CurvedAnimation(
-                          parent: _animationController,
-                          curve: const Interval(
-                            0.5,
-                            1.0,
-                            curve: Curves.easeOutQuad,
-                          ),
-                        ),
-                      )
-                      .value,
+                  offset: _animationController.eval(
+                    Tween<Offset>(
+                      begin: Offset(0, size - ballSize),
+                      end: Offset.zero,
+                    ),
+                    curve: const Interval(0.5, 1.0, curve: Curves.easeOutQuad),
+                  ),
                   child: Align(
                     alignment: Alignment.topCenter,
                     child: DrawDot.circular(

--- a/lib/src/discrete_circle/discrete_circle.dart
+++ b/lib/src/discrete_circle/discrete_circle.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
 import '../widgets/draw_arc.dart';
 import 'dart:math' as math;
 
@@ -45,18 +46,12 @@ class _DiscreteCircleState extends State<DiscreteCircle>
         return Stack(
           children: <Widget>[
             Transform.rotate(
-              angle: Tween<double>(begin: 0, end: 2 * math.pi)
-                  .animate(
-                    CurvedAnimation(
-                      parent: _animationController,
-                      curve: const Interval(
-                        0.68,
-                        0.95,
-                        curve: Curves.easeOut,
-                      ),
-                    ),
-                  )
-                  .value,
+              angle: _animationController.evalDouble(
+                to: 2 * math.pi,
+                begin: 0.68,
+                end: 0.95,
+                curve: Curves.easeOut,
+              ),
               child: Visibility(
                 visible: _animationController.value >= 0.5,
                 child: Arc.draw(
@@ -64,21 +59,13 @@ class _DiscreteCircleState extends State<DiscreteCircle>
                   size: size,
                   strokeWidth: strokeWidth,
                   startAngle: -math.pi / 2,
-                  endAngle: Tween<double>(
-                    begin: math.pi / 2,
-                    end: math.pi / (size * size),
-                  )
-                      .animate(
-                        CurvedAnimation(
-                          parent: _animationController,
-                          curve: const Interval(
-                            0.7,
-                            0.95,
-                            curve: Curves.easeOutSine,
-                          ),
-                        ),
-                      )
-                      .value,
+                  endAngle: _animationController.evalDouble(
+                    from: math.pi / 2,
+                    to: math.pi / (size * size),
+                    begin: 0.7,
+                    end: 0.95,
+                    curve: Curves.easeOutSine,
+                  ),
                 ),
               ),
             ),
@@ -89,58 +76,36 @@ class _DiscreteCircleState extends State<DiscreteCircle>
                 size: size,
                 strokeWidth: strokeWidth,
                 startAngle: -math.pi / 2,
-                endAngle: Tween<double>(
-                  begin: -2 * math.pi,
-                  end: math.pi / (size * size),
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.6,
-                          0.95,
-                          // curve: Curves.easeIn,
-                          curve: Curves.easeOutSine,
-                        ),
-                      ),
-                    )
-                    .value,
+                endAngle: _animationController.evalDouble(
+                  from: -2 * math.pi,
+                  to: math.pi / (size * size),
+                  begin: 0.6,
+                  end: 0.95,
+                  curve: Curves.easeOutSine,
+                ),
               ),
             ),
             Visibility(
               visible: _animationController.value <= 0.5,
               // visible: true,
               child: Transform.rotate(
-                angle: Tween<double>(begin: 0, end: math.pi * 0.06)
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.48,
-                          0.5,
-                        ),
-                      ),
-                    )
-                    .value,
+                angle: _animationController.evalDouble(
+                  to: math.pi * 0.06,
+                  begin: 0.48,
+                  end: 0.5,
+                ),
                 child: Arc.draw(
                   color: color,
                   size: size,
                   strokeWidth: strokeWidth,
                   startAngle: -math.pi / 2,
-                  // endAngle: 1.94 * math.pi,
-                  endAngle: Tween<double>(
-                          begin: math.pi / (size * size), end: 1.94 * math.pi)
-                      .animate(
-                        CurvedAnimation(
-                          parent: _animationController,
-                          curve: const Interval(
-                            0.05,
-                            0.48,
-                            curve: Curves.easeOutSine,
-                          ),
-                        ),
-                      )
-                      .value,
+                  endAngle: _animationController.evalDouble(
+                    from: math.pi / (size * size),
+                    to: 1.94 * math.pi,
+                    begin: 0.05,
+                    end: 0.48,
+                    curve: Curves.easeOutSine,
+                  ),
                 ),
               ),
             ),
@@ -151,23 +116,13 @@ class _DiscreteCircleState extends State<DiscreteCircle>
                 size: size,
                 strokeWidth: strokeWidth,
                 startAngle: -math.pi / 2,
-                // endAngle: -1.94 * math.pi
-                endAngle: Tween<double>(
-                  // begin: -2 * math.pi,
-                  begin: -1.94 * math.pi,
-                  end: math.pi / (size * size),
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.5,
-                          0.95,
-                          curve: Curves.easeOutSine,
-                        ),
-                      ),
-                    )
-                    .value,
+                endAngle: _animationController.evalDouble(
+                  from: -1.94 * math.pi,
+                  to: math.pi / (size * size),
+                  begin: 0.5,
+                  end: 0.95,
+                  curve: Curves.easeOutSine,
+                ),
               ),
             ),
           ],

--- a/lib/src/dots_triangle/build_sides.dart
+++ b/lib/src/dots_triangle/build_sides.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
 import '../widgets/rounded_rectangle.dart';
 
 class BuildSides extends StatelessWidget {
@@ -10,6 +12,7 @@ class BuildSides extends StatelessWidget {
   final double rotationAngle;
   final Offset rotationOrigin;
   final bool forward;
+
   const BuildSides.forward({
     Key? key,
     required this.maxLength,
@@ -42,43 +45,29 @@ class BuildSides extends StatelessWidget {
 
     final double endInterval = interval.end;
 
-    final CurvedAnimation leftCurvedAnimation = CurvedAnimation(
-      parent: controller,
-      curve: Interval(
-        startInterval,
-        middleInterval,
-      ),
-    );
-
-    final CurvedAnimation rightCurvedAnimation = CurvedAnimation(
-      parent: controller,
-      curve: Interval(
-        middleInterval,
-        endInterval,
-      ),
-    );
+    final Interval leftInterval = Interval(startInterval, middleInterval);
+    final Interval rightInterval = Interval(middleInterval, endInterval);
 
     final Widget firstChild = Visibility(
       visible: forward
           ? controller.value <= middleInterval
           : controller.value >= middleInterval,
       child: Transform.translate(
-        offset: Tween<Offset>(
-          begin: forward ? Offset.zero : Offset(offset, 0),
-          end: forward ? Offset(offset, 0) : Offset.zero,
-        )
-            .animate(
-              forward ? leftCurvedAnimation : rightCurvedAnimation,
-            )
-            .value,
+        offset: controller.eval(
+          Tween<Offset>(
+            begin: forward ? Offset.zero : Offset(offset, 0),
+            end: forward ? Offset(offset, 0) : Offset.zero,
+          ),
+          curve: forward ? leftInterval : rightInterval,
+        ),
         child: RoundedRectangle.horizontal(
-          width: Tween<double>(
-                  begin: forward ? depth : maxLength,
-                  end: forward ? maxLength : depth)
-              .animate(
-                forward ? leftCurvedAnimation : rightCurvedAnimation,
-              )
-              .value,
+          width: controller.eval(
+            Tween<double>(
+              begin: forward ? depth : maxLength,
+              end: forward ? maxLength : depth,
+            ),
+            curve: forward ? leftInterval : rightInterval,
+          ),
           height: depth,
           color: color,
         ),
@@ -90,22 +79,21 @@ class BuildSides extends StatelessWidget {
           ? controller.value >= middleInterval
           : controller.value <= middleInterval,
       child: Transform.translate(
-        offset: Tween<Offset>(
-          begin: forward ? Offset(-offset, 0) : Offset.zero,
-          end: forward ? Offset.zero : Offset(-offset, 0),
-        )
-            .animate(
-              forward ? rightCurvedAnimation : leftCurvedAnimation,
-            )
-            .value,
+        offset: controller.eval(
+          Tween<Offset>(
+            begin: forward ? Offset(-offset, 0) : Offset.zero,
+            end: forward ? Offset.zero : Offset(-offset, 0),
+          ),
+          curve: forward ? rightInterval : leftInterval,
+        ),
         child: RoundedRectangle.horizontal(
-          width: Tween<double>(
-                  begin: forward ? maxLength : depth,
-                  end: forward ? depth : maxLength)
-              .animate(
-                forward ? rightCurvedAnimation : leftCurvedAnimation,
-              )
-              .value,
+          width: controller.eval(
+            Tween<double>(
+              begin: forward ? maxLength : depth,
+              end: forward ? depth : maxLength,
+            ),
+            curve: forward ? rightInterval : leftInterval,
+          ),
           height: depth,
           color: color,
         ),

--- a/lib/src/falling_dot/falling_dot.dart
+++ b/lib/src/falling_dot/falling_dot.dart
@@ -1,7 +1,10 @@
-import 'package:flutter/material.dart';
-import '../widgets/draw_dot.dart';
 import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
 import '../widgets/draw_arc.dart';
+import '../widgets/draw_dot.dart';
 
 class FallingDot extends StatefulWidget {
   final double size;
@@ -21,6 +24,7 @@ class _FallingDotState extends State<FallingDot>
     with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
   final double startAngle = -math.pi / 4;
+
   @override
   void initState() {
     super.initState();
@@ -47,51 +51,26 @@ class _FallingDotState extends State<FallingDot>
     // final double dotOffset =
     //     (innerBoxSize - innerBoxSize / 2 - innerPadding / 2);
 
-    Color fallingFromTopDotColor() =>
-        ColorTween(begin: color.withOpacity(0.0), end: color)
-            .animate(
-              CurvedAnimation(
-                parent: _animationController,
-                curve: const Interval(
-                  0.0,
-                  0.2,
-                  curve: Curves.easeInOut,
-                ),
-              ),
-            )
-            .value!;
+    Color fallingFromTopDotColor() => _animationController.eval(
+          ColorTween(begin: color.withOpacity(0.0), end: color),
+          curve: const Interval(0.0, 0.2, curve: Curves.easeInOut),
+        )!;
 
-    double dotWidth() => Tween<double>(
-          begin: size * 0.01,
-          end: dotFinalSize,
-        )
-            .animate(
-              CurvedAnimation(
-                parent: _animationController,
-                curve: const Interval(
-                  0.15,
-                  0.3,
-                  curve: Curves.easeInOut,
-                ),
-              ),
-            )
-            .value;
+    double dotWidth() => _animationController.evalDouble(
+          from: size * 0.01,
+          to: dotFinalSize,
+          begin: 0.15,
+          end: 0.3,
+          curve: Curves.easeInOut,
+        );
 
-    double dotHeight() => Tween<double>(
-          begin: size * 0.1,
-          end: dotFinalSize,
-        )
-            .animate(
-              CurvedAnimation(
-                parent: _animationController,
-                curve: const Interval(
-                  0.15,
-                  0.3,
-                  curve: Curves.easeInOut,
-                ),
-              ),
-            )
-            .value;
+    double dotHeight() => _animationController.evalDouble(
+          from: size * 0.1,
+          to: dotFinalSize,
+          begin: 0.15,
+          end: 0.3,
+          curve: Curves.easeInOut,
+        );
 
     return Container(
       width: size,
@@ -110,21 +89,12 @@ class _FallingDotState extends State<FallingDot>
                 Visibility(
                   visible: _animationController.value <= 0.5,
                   child: Transform.rotate(
-                    angle: Tween<double>(
-                      begin: -math.pi,
-                      end: 0,
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: _animationController,
-                            curve: const Interval(
-                              0.0,
-                              0.3,
-                              curve: curve,
-                            ),
-                          ),
-                        )
-                        .value,
+                    angle: _animationController.evalDouble(
+                      from: -math.pi,
+                      to: 0,
+                      end: 0.3,
+                      curve: curve,
+                    ),
                     child: Arc.draw(
                       color: color,
                       size: size,
@@ -137,21 +107,12 @@ class _FallingDotState extends State<FallingDot>
                 Visibility(
                   visible: _animationController.value >= 0.5,
                   child: Transform.rotate(
-                    angle: Tween<double>(
-                      begin: 0,
-                      end: math.pi,
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: _animationController,
-                            curve: const Interval(
-                              0.5,
-                              0.8,
-                              curve: curve,
-                            ),
-                          ),
-                        )
-                        .value,
+                    angle: _animationController.evalDouble(
+                      to: math.pi,
+                      begin: 0.5,
+                      end: 0.8,
+                      curve: curve,
+                    ),
                     child: Arc.draw(
                       color: color,
                       size: size,
@@ -164,21 +125,13 @@ class _FallingDotState extends State<FallingDot>
                 Visibility(
                   visible: _animationController.value <= 0.5,
                   child: Transform.translate(
-                    offset: Tween<Offset>(
-                      begin: Offset(0, -size / 2),
-                      end: Offset.zero,
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: _animationController,
-                            curve: const Interval(
-                              0.1,
-                              0.3,
-                              curve: curve,
-                            ),
-                          ),
-                        )
-                        .value,
+                    offset: _animationController.eval(
+                      Tween<Offset>(
+                        begin: Offset(0, -size / 2),
+                        end: Offset.zero,
+                      ),
+                      curve: const Interval(0.1, 0.3, curve: curve),
+                    ),
                     child: DrawDot.elliptical(
                       width: dotWidth(),
                       height: dotHeight(),
@@ -189,36 +142,21 @@ class _FallingDotState extends State<FallingDot>
                 Visibility(
                   visible: _animationController.value >= 0.5,
                   child: Transform.translate(
-                    // offset: Offset(0, dotFinalSize),
-                    offset: Tween<Offset>(
-                      begin: Offset.zero,
-                      end: Offset(0, dotFinalSize),
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: _animationController,
-                            curve: const Interval(
-                              0.5,
-                              0.72,
-                              curve: Curves.easeInOut,
-                            ),
-                          ),
-                        )
-                        .value,
+                    offset: _animationController.eval(
+                      Tween<Offset>(
+                        begin: Offset.zero,
+                        end: Offset(0, dotFinalSize),
+                      ),
+                      curve: const Interval(0.5, 0.72, curve: Curves.easeInOut),
+                    ),
                     child: DrawDot.circular(
-                      // dotSize: dotFinalSize,
-                      dotSize: Tween<double>(begin: dotFinalSize, end: 0.0)
-                          .animate(
-                            CurvedAnimation(
-                              parent: _animationController,
-                              curve: const Interval(
-                                0.5,
-                                0.72,
-                                curve: Curves.easeInOut,
-                              ),
-                            ),
-                          )
-                          .value,
+                      dotSize: _animationController.evalDouble(
+                        from: dotFinalSize,
+                        to: 0.0,
+                        begin: 0.5,
+                        end: 0.72,
+                        curve: Curves.easeInOut,
+                      ),
                       color: color,
                     ),
                   ),

--- a/lib/src/flickr/flickr.dart
+++ b/lib/src/flickr/flickr.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
 
 class Flickr extends StatefulWidget {
   final Color leftDotColor;
@@ -19,6 +20,7 @@ class Flickr extends StatefulWidget {
 class _FlickrState extends State<Flickr> with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
   final Cubic curves = Curves.ease;
+
   @override
   void initState() {
     super.initState();
@@ -113,14 +115,10 @@ class _BuildDot extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Offset offsetAnimation = Tween<Offset>(
-      begin: initialOffset,
-      end: finalOffset,
-    )
-        .animate(
-          CurvedAnimation(parent: controller, curve: interval),
-        )
-        .value;
+    final Offset offsetAnimation = controller.eval(
+      Tween<Offset>(begin: initialOffset, end: finalOffset),
+      curve: interval,
+    );
 
     return Visibility(
       visible: visibility,

--- a/lib/src/four_rotating_dots/four_rotating_dots.dart
+++ b/lib/src/four_rotating_dots/four_rotating_dots.dart
@@ -1,10 +1,14 @@
-import 'package:flutter/material.dart';
-import '../widgets/draw_dot.dart';
 import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
+import '../widgets/draw_dot.dart';
 
 class FourRotatingDots extends StatefulWidget {
   final double size;
   final Color color;
+
   const FourRotatingDots({
     Key? key,
     required this.color,
@@ -39,17 +43,10 @@ class _FourRotatingDotsState extends State<FourRotatingDots>
     required double finalAngle,
     required Interval interval,
   }) {
-    final double angle = Tween<double>(
-      begin: initialAngle,
-      end: finalAngle,
-    )
-        .animate(
-          CurvedAnimation(
-            parent: _animationController,
-            curve: interval,
-          ),
-        )
-        .value;
+    final double angle = _animationController.eval(
+      Tween<double>(begin: initialAngle, end: finalAngle),
+      curve: interval,
+    );
     return Visibility(
       visible: visible,
       child: Transform.rotate(
@@ -101,61 +98,65 @@ class _FourRotatingDotsState extends State<FourRotatingDots>
     double? dotFinalSize,
     required bool visible,
   }) {
-    final CurvedAnimation curvedAnimation = CurvedAnimation(
-      parent: _animationController,
-      curve: interval,
-    );
-
     final double dotSize = fixedSize
         ? dotInitialSize
-        : Tween<double>(begin: dotInitialSize, end: dotFinalSize)
-            .animate(
-              CurvedAnimation(
-                parent: _animationController,
-                curve: interval,
-              ),
-            )
-            .value;
+        : _animationController.eval(
+            Tween<double>(begin: dotInitialSize, end: dotFinalSize),
+            curve: interval,
+          );
+
     return Visibility(
       visible: visible,
       child: Stack(
         alignment: Alignment.center,
         children: <Widget>[
           Transform.translate(
-            offset: Tween<Offset>(
-              begin: Offset(-initialOffset, 0),
-              end: Offset(-finalOffset, 0),
-            ).animate(curvedAnimation).value,
+            offset: _animationController.eval(
+              Tween<Offset>(
+                begin: Offset(-initialOffset, 0),
+                end: Offset(-finalOffset, 0),
+              ),
+              curve: interval,
+            ),
             child: DrawDot.circular(
               dotSize: dotSize,
               color: color,
             ),
           ),
           Transform.translate(
-            offset: Tween<Offset>(
-              begin: Offset(initialOffset, 0),
-              end: Offset(finalOffset, 0),
-            ).animate(curvedAnimation).value,
+            offset: _animationController.eval(
+              Tween<Offset>(
+                begin: Offset(initialOffset, 0),
+                end: Offset(finalOffset, 0),
+              ),
+              curve: interval,
+            ),
             child: DrawDot.circular(
               dotSize: dotSize,
               color: color,
             ),
           ),
           Transform.translate(
-            offset: Tween<Offset>(
-              begin: Offset(0, -initialOffset),
-              end: Offset(0, -finalOffset),
-            ).animate(curvedAnimation).value,
+            offset: _animationController.eval(
+              Tween<Offset>(
+                begin: Offset(0, -initialOffset),
+                end: Offset(0, -finalOffset),
+              ),
+              curve: interval,
+            ),
             child: DrawDot.circular(
               dotSize: dotSize,
               color: color,
             ),
           ),
           Transform.translate(
-            offset: Tween<Offset>(
-              begin: Offset(0, initialOffset),
-              end: Offset(0, finalOffset),
-            ).animate(curvedAnimation).value,
+            offset: _animationController.eval(
+              Tween<Offset>(
+                begin: Offset(0, initialOffset),
+                end: Offset(0, finalOffset),
+              ),
+              curve: interval,
+            ),
             child: DrawDot.circular(
               dotSize: dotSize,
               color: color,
@@ -184,21 +185,11 @@ class _FourRotatingDotsState extends State<FourRotatingDots>
             fit: StackFit.expand,
             children: <Widget>[
               Transform.rotate(
-                angle: Tween<double>(
+                angle: _animationController.evalDouble(
+                  to: math.pi / 8,
                   begin: 0.0,
-                  end: math.pi / 8,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.0,
-                          0.18,
-                          // curve: Curves.easeInCubic,
-                        ),
-                      ),
-                    )
-                    .value,
+                  end: 0.18,
+                ),
                 child: _animatingDots(
                   visible: _animationController.value <= 0.18,
                   fixedSize: true,
@@ -214,21 +205,12 @@ class _FourRotatingDotsState extends State<FourRotatingDots>
                 ),
               ),
               Transform.rotate(
-                angle: Tween<double>(
-                  begin: math.pi / 8,
-                  end: math.pi / 4,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.18,
-                          0.36,
-                          // curve: Curves.easeOutCubic,
-                        ),
-                      ),
-                    )
-                    .value,
+                angle: _animationController.evalDouble(
+                  from: math.pi / 8,
+                  to: math.pi / 4,
+                  begin: 0.18,
+                  end: 0.36,
+                ),
                 child: _animatingDots(
                   visible: _animationController.value >= 0.18 &&
                       _animationController.value <= 0.36,
@@ -260,20 +242,12 @@ class _FourRotatingDotsState extends State<FourRotatingDots>
                 offset: maxOffset,
               ),
               Transform.rotate(
-                angle: Tween<double>(
-                  begin: 7 * math.pi / 4,
-                  end: 2 * math.pi,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.6,
-                          0.78,
-                        ),
-                      ),
-                    )
-                    .value,
+                angle: _animationController.evalDouble(
+                  from: 7 * math.pi / 4,
+                  to: 2 * math.pi,
+                  begin: 0.6,
+                  end: 0.78,
+                ),
                 child: _animatingDots(
                   visible: _animationController.value >= 0.60 &&
                       _animationController.value <= 0.78,

--- a/lib/src/half_triangle_dot/half_triangle_dot.dart
+++ b/lib/src/half_triangle_dot/half_triangle_dot.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
 import '../widgets/draw_dot.dart';
 import '../widgets/draw_triangle.dart';
 
 class HalfTriangleDot extends StatefulWidget {
   final double size;
   final Color color;
+
   const HalfTriangleDot({
     Key? key,
     required this.size,
@@ -45,20 +48,10 @@ class _HalfTriangleDotState extends State<HalfTriangleDot>
     final double innerHeight = 0.74 * size;
     final double innerWidth = 0.87 * size;
     final double storkeWidth = size / 8;
-    final CurvedAnimation firstCurvedAnimation = CurvedAnimation(
-      parent: _animationController,
-      curve: Interval(0.0, 0.23, curve: curve),
-    );
 
-    final CurvedAnimation secondCurvedAnimation = CurvedAnimation(
-      parent: _animationController,
-      curve: Interval(0.33, 0.56, curve: curve),
-    );
-
-    final CurvedAnimation thirdCurvedAnimation = CurvedAnimation(
-      parent: _animationController,
-      curve: Interval(0.66, 0.89, curve: curve),
-    );
+    final Interval firstInterval = Interval(0.0, 0.23, curve: curve);
+    final Interval secondInterval = Interval(0.33, 0.56, curve: curve);
+    final Interval thirdInterval = Interval(0.66, 0.89, curve: curve);
 
     final Offset topLeftDotOffset = Offset(
       innerWidth / 4 - (storkeWidth / 2),
@@ -93,18 +86,24 @@ class _HalfTriangleDotState extends State<HalfTriangleDot>
                   child: Triangle.draw(
                     color: color,
                     strokeWidth: storkeWidth,
-                    start: Tween<Offset>(
-                      begin: Offset(innerWidth, innerHeight),
-                      end: Offset(innerWidth / 2, 0),
-                    ).animate(firstCurvedAnimation).value,
+                    start: _animationController.eval(
+                      Tween<Offset>(
+                        begin: Offset(innerWidth, innerHeight),
+                        end: Offset(innerWidth / 2, 0),
+                      ),
+                      curve: firstInterval,
+                    ),
                     middleLine: MiddleLine(
                       Offset(innerWidth, innerHeight),
                       Offset(0, innerHeight),
                     ),
-                    end: Tween<Offset>(
-                      begin: Offset(innerWidth / 2, 0),
-                      end: Offset(0, innerHeight),
-                    ).animate(firstCurvedAnimation).value,
+                    end: _animationController.eval(
+                      Tween<Offset>(
+                        begin: Offset(innerWidth / 2, 0),
+                        end: Offset(0, innerHeight),
+                      ),
+                      curve: firstInterval,
+                    ),
                   ),
                 ),
                 Visibility(
@@ -112,18 +111,24 @@ class _HalfTriangleDotState extends State<HalfTriangleDot>
                   child: Triangle.draw(
                     color: color,
                     strokeWidth: storkeWidth,
-                    start: Tween<Offset>(
-                      begin: Offset(innerWidth / 2, 0),
-                      end: Offset(0, innerHeight),
-                    ).animate(secondCurvedAnimation).value,
+                    start: _animationController.eval(
+                      Tween<Offset>(
+                        begin: Offset(innerWidth / 2, 0),
+                        end: Offset(0, innerHeight),
+                      ),
+                      curve: secondInterval,
+                    ),
                     middleLine: MiddleLine(
                       Offset(innerWidth / 2, 0),
                       Offset(innerWidth, innerHeight),
                     ),
-                    end: Tween<Offset>(
-                      begin: Offset(0, innerHeight),
-                      end: Offset(innerWidth, innerHeight),
-                    ).animate(secondCurvedAnimation).value,
+                    end: _animationController.eval(
+                      Tween<Offset>(
+                        begin: Offset(0, innerHeight),
+                        end: Offset(innerWidth, innerHeight),
+                      ),
+                      curve: secondInterval,
+                    ),
                   ),
                 ),
                 Visibility(
@@ -131,18 +136,24 @@ class _HalfTriangleDotState extends State<HalfTriangleDot>
                   child: Triangle.draw(
                     color: color,
                     strokeWidth: storkeWidth,
-                    start: Tween<Offset>(
-                      begin: Offset(0, innerHeight),
-                      end: Offset(innerWidth, innerHeight),
-                    ).animate(thirdCurvedAnimation).value,
+                    start: _animationController.eval(
+                      Tween<Offset>(
+                        begin: Offset(0, innerHeight),
+                        end: Offset(innerWidth, innerHeight),
+                      ),
+                      curve: thirdInterval,
+                    ),
                     middleLine: MiddleLine(
                       Offset(0, innerHeight),
                       Offset(innerWidth / 2, 0),
                     ),
-                    end: Tween<Offset>(
-                      begin: Offset(innerWidth, innerHeight),
-                      end: Offset(innerWidth / 2, 0),
-                    ).animate(thirdCurvedAnimation).value,
+                    end: _animationController.eval(
+                      Tween<Offset>(
+                        begin: Offset(innerWidth, innerHeight),
+                        end: Offset(innerWidth / 2, 0),
+                      ),
+                      curve: thirdInterval,
+                    ),
                   ),
                 ),
                 SizedBox(
@@ -154,11 +165,13 @@ class _HalfTriangleDotState extends State<HalfTriangleDot>
                       Visibility(
                         visible: _fistVisibility(_animationController),
                         child: Transform.translate(
-                          offset: Tween<Offset>(
-                                  begin: topRightDotOffset,
-                                  end: topLeftDotOffset)
-                              .animate(firstCurvedAnimation)
-                              .value,
+                          offset: _animationController.eval(
+                            Tween<Offset>(
+                              begin: topRightDotOffset,
+                              end: topLeftDotOffset,
+                            ),
+                            curve: firstInterval,
+                          ),
                           child: DrawDot.circular(
                             dotSize: storkeWidth,
                             color: color,
@@ -168,11 +181,13 @@ class _HalfTriangleDotState extends State<HalfTriangleDot>
                       Visibility(
                         visible: _secondVisibility(_animationController),
                         child: Transform.translate(
-                          offset: Tween<Offset>(
-                                  begin: topLeftDotOffset,
-                                  end: bottomMiddleDotOffset)
-                              .animate(secondCurvedAnimation)
-                              .value,
+                          offset: _animationController.eval(
+                            Tween<Offset>(
+                              begin: topLeftDotOffset,
+                              end: bottomMiddleDotOffset,
+                            ),
+                            curve: secondInterval,
+                          ),
                           child: DrawDot.circular(
                             dotSize: storkeWidth,
                             color: color,
@@ -182,11 +197,13 @@ class _HalfTriangleDotState extends State<HalfTriangleDot>
                       Visibility(
                         visible: _thirdVisibility(_animationController),
                         child: Transform.translate(
-                          offset: Tween<Offset>(
-                                  begin: bottomMiddleDotOffset,
-                                  end: topRightDotOffset)
-                              .animate(thirdCurvedAnimation)
-                              .value,
+                          offset: _animationController.eval(
+                            Tween<Offset>(
+                              begin: bottomMiddleDotOffset,
+                              end: topRightDotOffset,
+                            ),
+                            curve: thirdInterval,
+                          ),
                           child: DrawDot.circular(
                             dotSize: storkeWidth,
                             color: color,

--- a/lib/src/hexagon_dots/build_dot.dart
+++ b/lib/src/hexagon_dots/build_dot.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
 import '../widgets/draw_dot.dart';
 
 class BuildDot extends StatelessWidget {
@@ -37,29 +38,13 @@ class BuildDot extends StatelessWidget {
         child: UnconstrainedBox(
           child: DrawDot.circular(
             color: color,
-            dotSize: first
-                ? Tween<double>(
-                    begin: 0.0,
-                    end: size / 6,
-                  )
-                    .animate(
-                      CurvedAnimation(
-                        parent: controller,
-                        curve: interval,
-                      ),
-                    )
-                    .value
-                : Tween<double>(
-                    begin: size / 6,
-                    end: 0.0,
-                  )
-                    .animate(
-                      CurvedAnimation(
-                        parent: controller,
-                        curve: interval,
-                      ),
-                    )
-                    .value,
+            dotSize: controller.eval(
+              Tween<double>(
+                begin: first ? 0.0 : size / 6,
+                end: first ? size / 6 : 0.0,
+              ),
+              curve: interval,
+            )
           ),
         ),
       ),

--- a/lib/src/ink_drop/ink_drop.dart
+++ b/lib/src/ink_drop/ink_drop.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
 import 'dart:math' as math;
 import '../widgets/draw_arc.dart';
 
@@ -54,81 +55,56 @@ class _InkDropState extends State<InkDrop> with SingleTickerProviderStateMixin {
             Visibility(
               visible: _animationController.value <= 0.9,
               child: Transform.translate(
-                offset: Tween<Offset>(
-                  begin: Offset(0, -size),
-                  end: Offset.zero,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.05,
-                          0.4,
-                          curve: Curves.easeInCubic,
-                        ),
-                      ),
-                    )
-                    .value,
+                offset: _animationController.eval(
+                  Tween<Offset>(
+                    begin: Offset(0, -size),
+                    end: Offset.zero,
+                  ),
+                  curve: const Interval(
+                    0.05,
+                    0.4,
+                    curve: Curves.easeInCubic,
+                  ),
+                ),
                 child: Arc.draw(
                   strokeWidth: strokeWidth,
                   size: size,
                   color: color,
                   startAngle: -3 * math.pi / 2,
-                  // endAngle: math.pi / (size * size),
-                  endAngle: Tween<double>(
-                    begin: math.pi / (size * size),
-                    end: math.pi / 1.13,
-                  )
-                      .animate(
-                        CurvedAnimation(
-                          parent: _animationController,
-                          curve: const Interval(
-                            0.38,
-                            0.9,
-                          ),
-                        ),
-                      )
-                      .value,
+                  endAngle: _animationController.evalDouble(
+                    from: math.pi / (size * size),
+                    to: math.pi / 1.13,
+                    begin: 0.38,
+                    end: 0.9,
+                  ),
                 ),
               ),
             ),
             Visibility(
               visible: _animationController.value <= 0.9,
               child: Transform.translate(
-                offset: Tween<Offset>(
-                  begin: Offset(0, -size),
-                  end: Offset.zero,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.05,
-                          0.4,
-                          curve: Curves.easeInCubic,
-                        ),
-                      ),
-                    )
-                    .value,
+                offset: _animationController.eval(
+                  Tween<Offset>(
+                    begin: Offset(0, -size),
+                    end: Offset.zero,
+                  ),
+                  curve: const Interval(
+                    0.05,
+                    0.4,
+                    curve: Curves.easeInCubic,
+                  ),
+                ),
                 child: Arc.draw(
                   strokeWidth: strokeWidth,
                   size: size,
                   color: color,
                   startAngle: -3 * math.pi / 2,
-                  endAngle: Tween<double>(
-                    begin: math.pi / (size * size),
-                    end: -math.pi / 1.13,
-                  )
-                      .animate(
-                        CurvedAnimation(
-                          parent: _animationController,
-                          curve: const Interval(
-                            0.38,
-                            0.9,
-                          ),
-                        ),
-                      )
-                      .value,
+                  endAngle: _animationController.evalDouble(
+                    from: math.pi / (size * size),
+                    to: -math.pi / 1.13,
+                    begin: 0.38,
+                    end: 0.9,
+                  ),
                 ),
               ),
             ),
@@ -141,20 +117,12 @@ class _InkDropState extends State<InkDrop> with SingleTickerProviderStateMixin {
                 size: size,
                 color: color,
                 startAngle: -math.pi / 4,
-                endAngle: Tween<double>(
-                  begin: -math.pi / 7.4,
-                  end: -math.pi / 4,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.9,
-                          0.96,
-                        ),
-                      ),
-                    )
-                    .value,
+                endAngle: _animationController.evalDouble(
+                  from: -math.pi / 7.4,
+                  to: -math.pi / 4,
+                  begin: 0.9,
+                  end: 0.96,
+                ),
               ),
             ),
             // Left
@@ -165,22 +133,12 @@ class _InkDropState extends State<InkDrop> with SingleTickerProviderStateMixin {
                 size: size,
                 color: color,
                 startAngle: -3 * math.pi / 4,
-                // endAngle: math.pi / 4
-                // endAngle: math.pi / 7.4
-                endAngle: Tween<double>(
-                  begin: math.pi / 7.4,
-                  end: math.pi / 4,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.9,
-                          0.96,
-                        ),
-                      ),
-                    )
-                    .value,
+                endAngle: _animationController.evalDouble(
+                  from: math.pi / 7.4,
+                  to: math.pi / 4,
+                  begin: 0.9,
+                  end: 0.96,
+                ),
               ),
             ),
 
@@ -192,21 +150,11 @@ class _InkDropState extends State<InkDrop> with SingleTickerProviderStateMixin {
                 size: size,
                 color: color,
                 startAngle: -math.pi / 3.5,
-                // endAngle: math.pi / 28,
-                endAngle: Tween<double>(
-                  begin: math.pi / 1.273,
-                  end: math.pi / 28,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.9,
-                          1.0,
-                        ),
-                      ),
-                    )
-                    .value,
+                endAngle: _animationController.evalDouble(
+                  from: math.pi / 1.273,
+                  to: math.pi / 28,
+                  begin: 0.9,
+                ),
               ),
             ),
 
@@ -218,23 +166,11 @@ class _InkDropState extends State<InkDrop> with SingleTickerProviderStateMixin {
                 size: size,
                 color: color,
                 startAngle: math.pi / 0.778,
-                // endAngle: -math.pi / 1.273
-                // endAngle: -math.pi / 27
-
-                endAngle: Tween<double>(
-                  begin: -math.pi / 1.273,
-                  end: -math.pi / 27,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.9,
-                          1.0,
-                        ),
-                      ),
-                    )
-                    .value,
+                endAngle: _animationController.evalDouble(
+                  from: -math.pi / 1.273,
+                  to: -math.pi / 27,
+                  begin: 0.9,
+                ),
               ),
             ),
           ],

--- a/lib/src/newton_cradle/swivel_dot.dart
+++ b/lib/src/newton_cradle/swivel_dot.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
 import 'dart:math' as math;
 import '../widgets/draw_dot.dart';
 
@@ -47,21 +48,11 @@ class SwivelDot extends StatelessWidget {
           visible: controller.value <= thirdInterval,
           child: Transform.rotate(
             origin: rotationOrigin,
-            angle: Tween<double>(
-              begin: 0.0,
-              end: left ? math.pi / 5 : -math.pi / 5,
-            )
-                .animate(
-                  CurvedAnimation(
-                    parent: controller,
-                    curve: Interval(
-                      firstInterval,
-                      secondInterval,
-                      // curve: curve,
-                    ),
-                  ),
-                )
-                .value,
+            angle: controller.evalDouble(
+              to: math.pi / (left ? 5 : -5),
+              begin: firstInterval,
+              end: secondInterval,
+            ),
             child: DrawDot.circular(
               color: color,
               dotSize: dotSize,
@@ -72,21 +63,12 @@ class SwivelDot extends StatelessWidget {
           visible: controller.value >= thirdInterval,
           child: Transform.rotate(
             origin: rotationOrigin,
-            angle: Tween<double>(
-              begin: left ? math.pi / 5 : -math.pi / 5,
-              end: 0.0,
-            )
-                .animate(
-                  CurvedAnimation(
-                    parent: controller,
-                    curve: Interval(
-                      thirdInterval,
-                      fourthInterval,
-                      // curve: curve,
-                    ),
-                  ),
-                )
-                .value,
+            angle: controller.evalDouble(
+              from: math.pi / (left ? 5 : -5),
+              to: 0,
+              begin: thirdInterval,
+              end: fourthInterval,
+            ),
             child: DrawDot.circular(
               color: color,
               dotSize: dotSize,

--- a/lib/src/prograssive_dots/prograssive_dots.dart
+++ b/lib/src/prograssive_dots/prograssive_dots.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
 import '../widgets/draw_dot.dart';
 
 class PrograssiveDots extends StatefulWidget {
@@ -40,20 +42,13 @@ class _PrograssiveDotsState extends State<PrograssiveDots>
     final double previousDotPosition = -(gapBetweenDots + dotSize);
 
     Widget translatingDot() => Transform.translate(
-          offset: Tween<Offset>(
-            begin: Offset.zero,
-            end: Offset(previousDotPosition, 0),
-          )
-              .animate(
-                CurvedAnimation(
-                  parent: _animationController,
-                  curve: const Interval(
-                    0.22,
-                    0.82,
-                  ),
-                ),
-              )
-              .value,
+          offset: _animationController.eval(
+            Tween<Offset>(
+              begin: Offset.zero,
+              end: Offset(previousDotPosition, 0),
+            ),
+            curve: const Interval(0.22, 0.82),
+          ),
           child: DrawDot.circular(
             dotSize: dotSize,
             color: color,
@@ -61,17 +56,13 @@ class _PrograssiveDotsState extends State<PrograssiveDots>
         );
 
     Widget scalingDot(bool scaleDown, Interval interval) => Transform.scale(
-          scale: Tween<double>(
-            begin: scaleDown ? 1.0 : 0.0,
-            end: scaleDown ? 0.0 : 1.0,
-          )
-              .animate(
-                CurvedAnimation(
-                  parent: _animationController,
-                  curve: interval,
-                ),
-              )
-              .value,
+          scale: _animationController.eval(
+            Tween<double>(
+              begin: scaleDown ? 1.0 : 0.0,
+              end: scaleDown ? 0.0 : 1.0,
+            ),
+            curve: interval,
+          ),
           child: DrawDot.circular(
             dotSize: dotSize,
             color: color,

--- a/lib/src/staggered_dots_wave/staggered_dots_wave.dart
+++ b/lib/src/staggered_dots_wave/staggered_dots_wave.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
 
 class StaggeredDotsWave extends StatefulWidget {
   final double size;
@@ -149,30 +150,16 @@ class DotContainer extends StatelessWidget {
               opacity: controller.value <= offsetInterval.end ? 1 : 0,
               // opacity: 1,
               child: Transform.translate(
-                offset: Tween<Offset>(
-                  begin: Offset.zero,
-                  end: Offset(0, maxDy),
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: controller,
-                        curve: offsetInterval,
-                      ),
-                    )
-                    .value,
+                offset: controller.eval(
+                  Tween<Offset>(begin: Offset.zero, end: Offset(0, maxDy)),
+                  curve: offsetInterval,
+                ),
                 child: Container(
                   width: size * 0.13,
-                  height: Tween<double>(
-                    begin: size * 0.13,
-                    end: maxHeight,
-                  )
-                      .animate(
-                        CurvedAnimation(
-                          parent: controller,
-                          curve: heightInterval,
-                        ),
-                      )
-                      .value,
+                  height: controller.eval(
+                    Tween<double>(begin: size * 0.13, end: maxHeight),
+                    curve: heightInterval,
+                  ),
                   decoration: BoxDecoration(
                     color: color,
                     borderRadius: BorderRadius.circular(size),
@@ -183,30 +170,16 @@ class DotContainer extends StatelessWidget {
             Opacity(
               opacity: controller.value >= offsetInterval.end ? 1 : 0,
               child: Transform.translate(
-                offset: Tween<Offset>(
-                  begin: Offset(0, maxDy),
-                  end: Offset.zero,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: controller,
-                        curve: reverseOffsetInterval,
-                      ),
-                    )
-                    .value,
+                offset: controller.eval(
+                  Tween<Offset>(begin: Offset(0, maxDy), end: Offset.zero),
+                  curve: reverseOffsetInterval,
+                ),
                 child: Container(
                   width: size * 0.13,
-                  height: Tween<double>(
-                    end: size * 0.13,
-                    begin: maxHeight,
-                  )
-                      .animate(
-                        CurvedAnimation(
-                          parent: controller,
-                          curve: reverseHeightInterval,
-                        ),
-                      )
-                      .value,
+                  height: controller.eval(
+                    Tween<double>(begin: maxHeight, end: size * 0.13),
+                    curve: reverseHeightInterval,
+                  ),
                   decoration: BoxDecoration(
                     color: color,
                     borderRadius: BorderRadius.circular(size),

--- a/lib/src/stretched_dots/build_dot.dart
+++ b/lib/src/stretched_dots/build_dot.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
 import '../widgets/rounded_rectangle.dart';
 
 class BuildDot extends StatelessWidget {
@@ -35,29 +37,18 @@ class BuildDot extends StatelessWidget {
             ? Align(
                 alignment: Alignment.bottomCenter,
                 child: Transform.translate(
-                  offset: Tween<Offset>(
-                    begin: Offset.zero,
-                    end: Offset(0, -offset),
-                  )
-                      .animate(
-                        CurvedAnimation(
-                          parent: controller,
-                          curve: firstInterval,
-                        ),
-                      )
-                      .value,
+                  offset: controller.eval(
+                    Tween<Offset>(begin: Offset.zero, end: Offset(0, -offset)),
+                    curve: firstInterval,
+                  ),
                   child: RoundedRectangle.vertical(
                     width: dotWidth,
                     // height: height,
                     color: color,
-                    height: Tween<double>(begin: dotWidth, end: height)
-                        .animate(
-                          CurvedAnimation(
-                            parent: controller,
-                            curve: firstInterval,
-                          ),
-                        )
-                        .value,
+                    height: controller.eval(
+                      Tween<double>(begin: dotWidth, end: height),
+                      curve: firstInterval,
+                    ),
                   ),
                 ),
               )
@@ -66,28 +57,17 @@ class BuildDot extends StatelessWidget {
                 child: Align(
                   alignment: Alignment.topCenter,
                   child: Transform.translate(
-                    offset: Tween<Offset>(
-                            begin: Offset(0, offset), end: Offset.zero)
-                        .animate(
-                          CurvedAnimation(
-                            parent: controller,
-                            curve: secondInterval,
-                          ),
-                        )
-                        .value,
+                    offset: controller.eval(
+                      Tween<Offset>(begin: Offset(0, offset), end: Offset.zero),
+                      curve: secondInterval,
+                    ),
                     child: RoundedRectangle.vertical(
                       width: dotWidth,
-                      // height: height,
                       color: color,
-                      height: Tween<double>(
-                        begin: height,
-                        end: dotWidth,
-                      )
-                          .animate(CurvedAnimation(
-                            parent: controller,
-                            curve: secondInterval,
-                          ))
-                          .value,
+                      height: controller.eval(
+                        Tween<double>(begin: height, end: dotWidth),
+                        curve: secondInterval,
+                      ),
                     ),
                   ),
                 ),
@@ -101,30 +81,16 @@ class BuildDot extends StatelessWidget {
                 child: Align(
                   alignment: Alignment.topCenter,
                   child: Transform.translate(
-                    // offset: Offset(0, offset),
-                    offset: Tween<Offset>(
-                      begin: Offset.zero,
-                      end: Offset(0, offset),
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: controller,
-                            curve: thirdInterval,
-                          ),
-                        )
-                        .value,
+                    offset: controller.eval(
+                      Tween<Offset>(begin: Offset.zero, end: Offset(0, offset)),
+                      curve: thirdInterval,
+                    ),
                     child: RoundedRectangle.vertical(
                       width: dotWidth,
-                      // height: height,
-                      height: Tween<double>(
-                        begin: dotWidth,
-                        end: height,
-                      )
-                          .animate(CurvedAnimation(
-                            parent: controller,
-                            curve: thirdInterval,
-                          ))
-                          .value,
+                      height: controller.eval(
+                        Tween<double>(begin: dotWidth, end: height),
+                        curve: thirdInterval,
+                      ),
                       color: color,
                     ),
                   ),
@@ -133,30 +99,16 @@ class BuildDot extends StatelessWidget {
             : Align(
                 alignment: Alignment.bottomCenter,
                 child: Transform.translate(
-                  offset: Tween<Offset>(
-                    begin: Offset(0, -offset),
-                    end: Offset.zero,
-                  )
-                      .animate(
-                        CurvedAnimation(
-                          parent: controller,
-                          curve: forthInterval,
-                        ),
-                      )
-                      .value,
+                  offset: controller.eval(
+                    Tween<Offset>(begin: Offset(0, -offset), end: Offset.zero),
+                    curve: forthInterval,
+                  ),
                   child: RoundedRectangle.vertical(
                     width: dotWidth,
-                    height: Tween<double>(
-                      begin: height,
-                      end: dotWidth,
-                    )
-                        .animate(
-                          CurvedAnimation(
-                            parent: controller,
-                            curve: forthInterval,
-                          ),
-                        )
-                        .value,
+                    height: controller.eval(
+                      Tween<double>(begin: height, end: dotWidth),
+                      curve: forthInterval,
+                    ),
                     color: color,
                   ),
                 ),

--- a/lib/src/three_arched_circle/three_arched_circle.dart
+++ b/lib/src/three_arched_circle/three_arched_circle.dart
@@ -1,6 +1,9 @@
-import 'package:flutter/material.dart';
-import '../widgets/draw_arc.dart';
 import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
+import '../widgets/draw_arc.dart';
 
 const double _kGapAngle = math.pi / 12;
 const double _kMinAngle = math.pi / 36;
@@ -8,6 +11,7 @@ const double _kMinAngle = math.pi / 36;
 class ThreeArchedCircle extends StatefulWidget {
   final double size;
   final Color color;
+
   const ThreeArchedCircle({
     Key? key,
     required this.color,
@@ -38,40 +42,28 @@ class _ThreeArchedCircleState extends State<ThreeArchedCircle>
     final double size = widget.size;
     final double ringWidth = size * 0.08;
 
-    final CurvedAnimation _firstRotationInterval = CurvedAnimation(
-      parent: _animationController,
-      curve: const Interval(
-        0.0,
-        0.5,
-        curve: Curves.easeInOut,
-      ),
+    const Interval firstRotationInterval = Interval(
+      0.0,
+      0.5,
+      curve: Curves.easeInOut,
     );
 
-    final CurvedAnimation _firstArchInterval = CurvedAnimation(
-      parent: _animationController,
-      curve: const Interval(
-        0.0,
-        0.4,
-        curve: Curves.easeInOut,
-      ),
+    const Interval firstArchInterval = Interval(
+      0.0,
+      0.4,
+      curve: Curves.easeInOut,
     );
 
-    final CurvedAnimation _secondRotationInterval = CurvedAnimation(
-      parent: _animationController,
-      curve: const Interval(
-        0.5,
-        1.0,
-        curve: Curves.easeInOut,
-      ),
+    const Interval secondRotationInterval = Interval(
+      0.5,
+      1.0,
+      curve: Curves.easeInOut,
     );
 
-    final CurvedAnimation _secondArchInterval = CurvedAnimation(
-      parent: _animationController,
-      curve: const Interval(
-        0.5,
-        0.9,
-        curve: Curves.easeInOut,
-      ),
+    const Interval secondArchInterval = Interval(
+      0.5,
+      0.9,
+      curve: Curves.easeInOut,
     );
 
     return Container(
@@ -84,10 +76,10 @@ class _ThreeArchedCircleState extends State<ThreeArchedCircle>
         builder: (_, __) {
           return _animationController.value <= 0.5
               ? Transform.rotate(
-                  angle: Tween<double>(
-                    begin: 0,
-                    end: 4 * math.pi / 3,
-                  ).animate(_firstRotationInterval).value,
+                  angle: _animationController.eval(
+                    Tween<double>(begin: 0, end: 4 * math.pi / 3),
+                    curve: firstRotationInterval,
+                  ),
                   child: Stack(
                     alignment: Alignment.center,
                     children: <Widget>[
@@ -96,39 +88,51 @@ class _ThreeArchedCircleState extends State<ThreeArchedCircle>
                         size: size,
                         strokeWidth: ringWidth,
                         startAngle: 7 * math.pi / 6,
-                        endAngle: Tween<double>(
-                          begin: 2 * math.pi / 3 - _kGapAngle,
-                          end: _kMinAngle,
-                        ).animate(_firstArchInterval).value,
+                        endAngle: _animationController.eval(
+                          Tween<double>(
+                            begin: 2 * math.pi / 3 - _kGapAngle,
+                            end: _kMinAngle,
+                          ),
+                          curve: firstArchInterval,
+                        ),
                       ),
                       Arc.draw(
                         color: color,
                         size: size,
                         strokeWidth: ringWidth,
                         startAngle: math.pi / 2,
-                        endAngle: Tween<double>(
-                          begin: 2 * math.pi / 3 - _kGapAngle,
-                          end: _kMinAngle,
-                        ).animate(_firstArchInterval).value,
+                        endAngle: _animationController.eval(
+                          Tween<double>(
+                            begin: 2 * math.pi / 3 - _kGapAngle,
+                            end: _kMinAngle,
+                          ),
+                          curve: firstArchInterval,
+                        ),
                       ),
                       Arc.draw(
                         color: color,
                         size: size,
                         strokeWidth: ringWidth,
                         startAngle: -math.pi / 6,
-                        endAngle: Tween<double>(
-                          begin: 2 * math.pi / 3 - _kGapAngle,
-                          end: _kMinAngle,
-                        ).animate(_firstArchInterval).value,
+                        endAngle: _animationController.eval(
+                          Tween<double>(
+                            begin: 2 * math.pi / 3 - _kGapAngle,
+                            end: _kMinAngle,
+                          ),
+                          curve: firstArchInterval,
+                        ),
                       ),
                     ],
                   ),
                 )
               : Transform.rotate(
-                  angle: Tween<double>(
-                    begin: 4 * math.pi / 3,
-                    end: (4 * math.pi / 3) + (2 * math.pi / 3),
-                  ).animate(_secondRotationInterval).value,
+                  angle: _animationController.eval(
+                    Tween<double>(
+                      begin: 4 * math.pi / 3,
+                      end: (4 * math.pi / 3) + (2 * math.pi / 3),
+                    ),
+                    curve: secondRotationInterval,
+                  ),
                   child: Stack(
                     alignment: Alignment.center,
                     children: <Widget>[
@@ -137,30 +141,39 @@ class _ThreeArchedCircleState extends State<ThreeArchedCircle>
                         size: size,
                         strokeWidth: ringWidth,
                         startAngle: 7 * math.pi / 6,
-                        endAngle: Tween<double>(
-                          begin: _kMinAngle,
-                          end: 2 * math.pi / 3 - _kGapAngle,
-                        ).animate(_secondArchInterval).value,
+                        endAngle: _animationController.eval(
+                          Tween<double>(
+                            begin: _kMinAngle,
+                            end: 2 * math.pi / 3 - _kGapAngle,
+                          ),
+                          curve: secondArchInterval,
+                        ),
                       ),
                       Arc.draw(
                         color: color,
                         size: size,
                         strokeWidth: ringWidth,
                         startAngle: math.pi / 2,
-                        endAngle: Tween<double>(
-                          begin: _kMinAngle,
-                          end: 2 * math.pi / 3 - _kGapAngle,
-                        ).animate(_secondArchInterval).value,
+                        endAngle: _animationController.eval(
+                          Tween<double>(
+                            begin: _kMinAngle,
+                            end: 2 * math.pi / 3 - _kGapAngle,
+                          ),
+                          curve: secondArchInterval,
+                        ),
                       ),
                       Arc.draw(
                         color: color,
                         size: size,
                         strokeWidth: ringWidth,
                         startAngle: -math.pi / 6,
-                        endAngle: Tween<double>(
-                          begin: _kMinAngle,
-                          end: 2 * math.pi / 3 - _kGapAngle,
-                        ).animate(_secondArchInterval).value,
+                        endAngle: _animationController.eval(
+                          Tween<double>(
+                            begin: _kMinAngle,
+                            end: 2 * math.pi / 3 - _kGapAngle,
+                          ),
+                          curve: secondArchInterval,
+                        ),
                       ),
                     ],
                   ),

--- a/lib/src/three_rotating_dots/three_rotating_dots.dart
+++ b/lib/src/three_rotating_dots/three_rotating_dots.dart
@@ -1,6 +1,9 @@
-import 'package:flutter/material.dart';
-import '../widgets/draw_dot.dart';
 import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
+import '../widgets/draw_dot.dart';
 
 class ThreeRotatingDots extends StatefulWidget {
   final double size;
@@ -174,26 +177,18 @@ class _BuildDot extends StatelessWidget {
           ? controller.value <= interval.end
           : controller.value >= interval.begin,
       child: Transform.rotate(
-        angle: Tween<double>(
-          begin: beginAngle,
-          end: endAngle,
-        )
-            .animate(
-              CurvedAnimation(parent: controller, curve: interval),
-            )
-            .value,
+        angle: controller.eval(
+          Tween<double>(begin: beginAngle, end: endAngle),
+          curve: interval,
+        ),
         child: Transform.translate(
-          offset: Tween<Offset>(
-            begin: first ? Offset.zero : Offset(0, -dotOffset),
-            end: first ? Offset(0, -dotOffset) : Offset.zero,
-          )
-              .animate(
-                CurvedAnimation(
-                  parent: controller,
-                  curve: interval,
-                ),
-              )
-              .value,
+          offset: controller.eval(
+            Tween<Offset>(
+              begin: first ? Offset.zero : Offset(0, -dotOffset),
+              end: first ? Offset(0, -dotOffset) : Offset.zero,
+            ),
+            curve: interval,
+          ),
           child: DrawDot.circular(
             color: color,
             dotSize: size,

--- a/lib/src/twisting_dots/twisting_dots.dart
+++ b/lib/src/twisting_dots/twisting_dots.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
 import '../widgets/draw_dot.dart';
 import 'dart:math' as math;
 
@@ -49,21 +50,11 @@ class _TwistingDotsState extends State<TwistingDots>
             Visibility(
               visible: _animationController.value < 0.5,
               child: Transform.rotate(
-                angle: Tween<double>(
-                  begin: 0,
-                  end: math.pi,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.0,
-                          0.5,
-                          curve: Curves.elasticOut,
-                        ),
-                      ),
-                    )
-                    .value,
+                angle: _animationController.evalDouble(
+                  to: math.pi,
+                  end: 0.5,
+                  curve: Curves.elasticOut,
+                ),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: <Widget>[
@@ -82,21 +73,12 @@ class _TwistingDotsState extends State<TwistingDots>
             Visibility(
               visible: _animationController.value > 0.5,
               child: Transform.rotate(
-                angle: Tween<double>(
-                  begin: -math.pi,
-                  end: 0,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: const Interval(
-                          0.5,
-                          1.0,
-                          curve: Curves.elasticOut,
-                        ),
-                      ),
-                    )
-                    .value,
+                angle: _animationController.evalDouble(
+                  from: -math.pi,
+                  to: 0,
+                  begin: 0.5,
+                  curve: Curves.elasticOut,
+                ),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: <Widget>[

--- a/lib/src/two_rotating_arc/two_rotating_arc.dart
+++ b/lib/src/two_rotating_arc/two_rotating_arc.dart
@@ -1,10 +1,14 @@
-import 'package:flutter/material.dart';
-import '../widgets/draw_arc.dart';
 import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
+
+import '../widgets/draw_arc.dart';
 
 class TwoRotatingArc extends StatefulWidget {
   final double size;
   final Color color;
+
   const TwoRotatingArc({
     Key? key,
     required this.color,
@@ -44,84 +48,44 @@ class _TwoRotatingArcState extends State<TwoRotatingArc>
           Visibility(
             visible: _animationController.value <= 0.5,
             child: Transform.rotate(
-              angle: Tween<double>(
-                begin: 0.0,
-                end: 3 * math.pi / 4,
-              )
-                  .animate(
-                    CurvedAnimation(
-                      parent: _animationController,
-                      curve: Interval(
-                        0.0,
-                        0.5,
-                        curve: firstCurve,
-                      ),
-                    ),
-                  )
-                  .value,
-              child: Arc.draw(
-                color: color,
-                size: size,
-                strokeWidth: strokeWidth,
-                startAngle: -math.pi / 2,
-                // endAngle: math.pi / (size * size),
-                endAngle: Tween<double>(
-                  begin: math.pi / (size * size),
-                  end: -math.pi / 2,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: Interval(
-                          0.0,
-                          0.5,
-                          curve: firstCurve,
-                        ),
-                      ),
-                    )
-                    .value,
+              angle: _animationController.evalDouble(
+                to: 3 * math.pi / 4,
+                end: 0.5,
+                curve: firstCurve,
               ),
+              child: Arc.draw(
+                  color: color,
+                  size: size,
+                  strokeWidth: strokeWidth,
+                  startAngle: -math.pi / 2,
+                  endAngle: _animationController.evalDouble(
+                    from: math.pi / (size * size),
+                    to: -math.pi / 2,
+                    end: 0.5,
+                    curve: firstCurve,
+                  )),
             ),
           ),
           Visibility(
             visible: _animationController.value >= 0.5,
             child: Transform.rotate(
-              angle: Tween<double>(
-                begin: math.pi / 4,
-                end: math.pi,
-              )
-                  .animate(
-                    CurvedAnimation(
-                      parent: _animationController,
-                      curve: Interval(
-                        0.5,
-                        1.0,
-                        curve: secondCurve,
-                      ),
-                    ),
-                  )
-                  .value,
+              angle: _animationController.evalDouble(
+                from: math.pi / 4,
+                to: math.pi,
+                begin: 0.5,
+                curve: secondCurve,
+              ),
               child: Arc.draw(
                 color: color,
                 size: size,
                 strokeWidth: strokeWidth,
                 startAngle: -math.pi / 2,
-                // endAngle: math.pi / (size * size),
-                endAngle: Tween<double>(
-                  begin: math.pi / 2,
-                  end: math.pi / (size * size),
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: Interval(
-                          0.5,
-                          1.0,
-                          curve: secondCurve,
-                        ),
-                      ),
-                    )
-                    .value,
+                endAngle: _animationController.evalDouble(
+                  from: math.pi / 2,
+                  to: math.pi / (size * size),
+                  begin: 0.5,
+                  curve: secondCurve,
+                ),
               ),
             ),
           ),
@@ -133,77 +97,47 @@ class _TwoRotatingArcState extends State<TwoRotatingArc>
           Visibility(
             visible: _animationController.value <= 0.5,
             child: Transform.rotate(
-              angle: Tween<double>(begin: -math.pi, end: -math.pi / 4)
-                  .animate(
-                    CurvedAnimation(
-                      parent: _animationController,
-                      curve: Interval(0.0, 0.5, curve: firstCurve),
-                    ),
-                  )
-                  .value,
+              angle: _animationController.evalDouble(
+                from: -math.pi,
+                to: -math.pi / 4,
+                end: 0.5,
+                curve: firstCurve,
+              ),
               child: Arc.draw(
                 color: color,
                 size: size,
                 strokeWidth: strokeWidth,
                 startAngle: -math.pi / 2,
-                // endAngle: math.pi / (size * size),
-                endAngle: Tween<double>(
-                  begin: math.pi / (size * size),
-                  end: -math.pi / 2,
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: Interval(
-                          0.0,
-                          0.5,
-                          curve: firstCurve,
-                        ),
-                      ),
-                    )
-                    .value,
+                endAngle: _animationController.evalDouble(
+                  from: math.pi / (size * size),
+                  to: -math.pi / 2,
+                  end: 0.5,
+                  curve: firstCurve,
+                ),
               ),
             ),
           ),
           Visibility(
             visible: _animationController.value >= 0.5,
             child: Transform.rotate(
-              angle: Tween<double>(
-                begin: -3 * math.pi / 4,
-                end: 0.0,
-              )
-                  .animate(
-                    CurvedAnimation(
-                      parent: _animationController,
-                      curve: Interval(
-                        0.5,
-                        1.0,
-                        curve: secondCurve,
-                      ),
-                    ),
-                  )
-                  .value,
+              angle: _animationController.evalDouble(
+                from: -3 * math.pi / 4,
+                to: 0.0,
+                begin: 0.5,
+                end: 1.0,
+                curve: secondCurve,
+              ),
               child: Arc.draw(
                 color: color,
                 size: size,
                 strokeWidth: strokeWidth,
                 startAngle: -math.pi / 2,
-                // endAngle: math.pi / (size * size),
-                endAngle: Tween<double>(
-                  begin: math.pi / 2,
-                  end: math.pi / (size * size),
-                )
-                    .animate(
-                      CurvedAnimation(
-                        parent: _animationController,
-                        curve: Interval(
-                          0.5,
-                          1.0,
-                          curve: secondCurve,
-                        ),
-                      ),
-                    )
-                    .value,
+                endAngle: _animationController.evalDouble(
+                  from: math.pi / 2,
+                  to: math.pi / (size * size),
+                  begin: 0.5,
+                  curve: secondCurve,
+                ),
               ),
             ),
           ),

--- a/lib/src/util/animation_controller_utils.dart
+++ b/lib/src/util/animation_controller_utils.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/widgets.dart';
+
+extension LoadingAnimationControllerX on AnimationController {
+  T eval<T>(Tween<T> tween, {Curve curve = Curves.linear}) =>
+      tween.transform(curve.transform(value));
+
+  double evalDouble({
+    double from = 0,
+    double to = 1,
+    double begin = 0,
+    double end = 1,
+    Curve curve = Curves.linear,
+  }) {
+    return eval(
+      Tween<double>(begin: from, end: to),
+      curve: Interval(begin, end, curve: curve),
+    );
+  }
+}

--- a/lib/src/wave_dots/wave_dots.dart
+++ b/lib/src/wave_dots/wave_dots.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:loading_animation_widget/src/util/animation_controller_utils.dart';
 
 class WaveDots extends StatefulWidget {
   final double size;
@@ -32,14 +33,10 @@ class _WaveDotsState extends State<WaveDots>
           required Offset end,
           required Interval interval}) =>
       Transform.translate(
-        offset: Tween<Offset>(begin: begin, end: end)
-            .animate(
-              CurvedAnimation(
-                parent: _controller,
-                curve: interval,
-              ),
-            )
-            .value,
+        offset: _controller.eval(
+          Tween<Offset>(begin: begin, end: end),
+          curve: interval,
+        ),
         child: Container(
           width: widget.size / 5,
           height: widget.size / 5,


### PR DESCRIPTION
I love the loaders provided by this library! However, during performance-profiling my project I discovered that almost every animation in this library has a memory leak caused by creating `CurvedAnimation` instances every build (they register a listener on the parent `AnimationController`, preventing it from being GCed until the parent `AnimationController` is disposed).

The memory leak isn't a big deal when the whole animation is disposed quickly, however in real life it's not that hard to leave the animation long-running (e.g. in the background). At 60FPS this can quickly increase the application's memory usage (in my - pretty extreme - case it amounted to additional 400MB of just `CurvedAnimation`s after leaving the app open for some time).

This PR fixes all of these leaks by replacing `CurvedAnimation`s by just a direct evaluation of specific `Tween`s and `Interval`s.